### PR TITLE
Update README.md to correct file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ For now you might want to just copy the `base.html` to your own template folder.
 
     mkdir templates
     cd templates
-    cp ../apps/ed-questionnaire/example/templates/base.html .
+    cp ./apps/ed-questionnaire/example/templates/base.html .
 
 Congratulations, you have setup the basics of the questionnaire! At this point this site doesn't really do anything, as there are no questionnaires defined.
 


### PR DESCRIPTION
In this context the user is told to create a `templates` folder inside the folder that contains `manage.py`, that is, `mysite/mysite/` -- if we were to use the original path, that would point to `mysite/apps/ed-questionnaire/example/templates/base.html` (which doesn't exist).
