### PR TITLE
Fix CSV download problem and simplify export_csv view code

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Activate your virtual environment
 
     source bin/activate
 
-Install Django
+Install Django and other dependencies
 
-    pip install django
+    pip install django unicodecsv
 
 Create your Django site
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ First, create a folder for your new site:
 
 Create a virtual environment so your python packages don't influence your system
     
-    virtualenv --no-site-packages -p python2.5 .
+    virtualenv --no-site-packages -p python2.7 .
 
 Activate your virtual environment
 


### PR DESCRIPTION
Replaced UnicodeWriter class with standard unicodecsv package.

Tested this patch with django 1.8.17 and 1.7.11 (python 2.7, Ubuntu 14.04 ,Sqlite3);  in both cases for me, CSV download fails without this patch, and succeeds with this patch.